### PR TITLE
Fix SQLite detection with cmake 3.14 and newer

### DIFF
--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -12,10 +12,10 @@ if(CMAKE_VERSION VERSION_LESS 3.14.0)
   list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR/cmake)
   find_package(Sqlite)
 else ()
-  find_package(Sqlite3)
+  find_package(SQLite3)
 endif ()
 
-if (NOT SQLITE_FOUND OR APPLE OR WIN32 OR QT_ANDROID)
+if (NOT (SQLITE_FOUND OR SQLite3_FOUND) OR APPLE OR WIN32 OR QT_ANDROID)
   message(STATUS "Using bundled sqlite3 library.")
   add_library(
     SQLITE3 STATIC ${CMAKE_CURRENT_LIST_DIR}/src/sqlite3.c
@@ -33,6 +33,10 @@ if (NOT SQLITE_FOUND OR APPLE OR WIN32 OR QT_ANDROID)
   endif (UNIX AND NOT APPLE)
 
 else ()
+  if( SQLite3_FOUND)
+    set(SQLITE_INCLUDE_DIR ${SQLite3_INCLUDE_DIR})
+    set(SQLITE_LIBRARIES ${SQLite3_LIBRARIES})
+  endif()
   target_include_directories(_SQLITE INTERFACE ${SQLITE_INCLUDE_DIR})
   target_link_libraries(_SQLITE INTERFACE ${SQLITE_LIBRARIES})
   file(STRINGS "${SQLITE_INCLUDE_DIR}/sqlite3.h" SQLITE_VERSION_LINE

--- a/sqlite/CMakeLists.txt
+++ b/sqlite/CMakeLists.txt
@@ -4,16 +4,20 @@ if (TARGET ocpn::sqlite)
   return()
 endif ()
 
+option(SQLITE_DISABLE_EXTENSIONS "Build SQLite with dynamic extension module support disabled" ON)
+option(SQLITE_FORCE_BUNDLED "Force build of bundled SQLite source, without looking for system libraries" OFF)
 
 add_library(_SQLITE INTERFACE)
 add_library(ocpn::sqlite ALIAS _SQLITE)
 
-if(CMAKE_VERSION VERSION_LESS 3.14.0)
-  list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR/cmake)
-  find_package(Sqlite)
-else ()
-  find_package(SQLite3)
-endif ()
+if(NOT SQLITE_FORCE_BUNDLED)
+  if(CMAKE_VERSION VERSION_LESS 3.14.0)
+    list(APPEND CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR/cmake)
+    find_package(Sqlite)
+  else ()
+    find_package(SQLite3)
+  endif ()
+endif()
 
 if (NOT (SQLITE_FOUND OR SQLite3_FOUND) OR APPLE OR WIN32 OR QT_ANDROID)
   message(STATUS "Using bundled sqlite3 library.")
@@ -26,10 +30,12 @@ if (NOT (SQLITE_FOUND OR SQLite3_FOUND) OR APPLE OR WIN32 OR QT_ANDROID)
     _SQLITE INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include
   )
 
-  # We do not need extensions, and using them in a static library causes trouble
-  # with libdl linking order.
+  # We usually do not need extensions, and using them in a static library
+  # possibly causes trouble with libdl linking order.
   if (UNIX AND NOT APPLE)
-    add_definitions(" -DSQLITE_OMIT_LOAD_EXTENSION")
+    if (SQLITE_DISABLE_EXTENSIONS)
+      add_definitions(" -DSQLITE_OMIT_LOAD_EXTENSION")
+    endif()
   endif (UNIX AND NOT APPLE)
 
 else ()


### PR DESCRIPTION
The [cmake module in current versions](https://gitlab.kitware.com/cmake/cmake/-/blob/master/Modules/FindSQLite3.cmake?ref_type=heads) is called `SQLite3` and produces variables with `SQLite3` prefix