### PR TITLE
BUG: fix XTE checksum index. Add optional 'mode' field

### DIFF
--- a/nmea0183/src/dpt.cpp
+++ b/nmea0183/src/dpt.cpp
@@ -71,7 +71,7 @@ bool DPT::Parse(const SENTENCE& sentence) {
   ** Field Number:
   **  1) Depth, meters
   **  2) Offset from transducer,
-  **     positive means distance from tansducer to water line
+  **     positive means distance from transducer to water line
   **     negative means distance from transducer to keel
   **  3) Checksum
   */

--- a/nmea0183/src/xte.hpp
+++ b/nmea0183/src/xte.hpp
@@ -59,6 +59,7 @@ class XTE : public RESPONSE
       double           CrossTrackErrorDistance;
       LEFTRIGHT        DirectionToSteer;
       wxString          CrossTrackUnits;
+      wxString          FAAModeIndicator;
 
       /*
       ** Methods


### PR DESCRIPTION
1. Fix checksum validation error for the XTE sentence. The `XTE::Parse()` function was always returning an invalid checksum.
2. Support the optional FAA Mode Indicator field introduced in NMEA 2.3 specification
3. Improved checksum validation to handle both NMEA 2.1 and 2.3+ formats
4. Fix typo

NMEA 2.1 format:
```
$--XTE,A,A,x.x,a,N*hh<CR><LF>
```

NMEA 2.3+ format:
```
$--XTE,A,A,x.x,a,N,m*hh<CR><LF>
```
