### PR TITLE
DrawText() for Android

### DIFF
--- a/plugin_dc/dc_utils/src/pidc.cpp
+++ b/plugin_dc/dc_utils/src/pidc.cpp
@@ -177,7 +177,14 @@ piDC::~piDC() {
 }
 
 void piDC::Init() {
-  m_buseTex = false; //GetLocaleCanonicalName().IsSameAs(_T("en_US"));
+  //m_buseTex = false 
+  //GetLocaleCanonicalName().IsSameAs(_T("en_US"));
+
+#ifdef __ANDROID__
+  m_buseTex = true;
+#else
+  m_buseTex = false;
+#endif
 
 #if wxUSE_GRAPHICS_CONTEXT
   pgc = NULL;


### PR DESCRIPTION
Temporary fix to allow Android to DrawText(). Only "en_US". This affects Android otcurrent_pi, frcurrents_pi, ocpn_draw_pi.